### PR TITLE
fix: 러닝결과 저장시 스크린샷에 경로가 보여지지 않는현상 (#6)

### DIFF
--- a/TrackUs/TrackUs.xcodeproj/project.pbxproj
+++ b/TrackUs/TrackUs.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		8280E0A82B6CFE7C00D1FB1A /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8280E0A72B6CFE7C00D1FB1A /* UINavigationController+.swift */; };
 		828EA4BD2B7CB2BC00785D0F /* GraphicTextCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828EA4BC2B7CB2BC00785D0F /* GraphicTextCard.swift */; };
 		828EA4BF2B7CB63100785D0F /* BorderLineModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828EA4BE2B7CB63100785D0F /* BorderLineModifier.swift */; };
+		829DFDC52BB3478200CD4C1D /* MapboxMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829DFDC42BB3478200CD4C1D /* MapboxMapView.swift */; };
 		829FF7732B6BAAF800C1ED4E /* View+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 829FF7722B6BAAF800C1ED4E /* View+Keyboard.swift */; };
 		82AB28B12B6B4DC200D7734D /* MenuItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB28B02B6B4DC200D7734D /* MenuItems.swift */; };
 		82AB28B32B6B4F0E00D7734D /* RunningRecordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AB28B22B6B4F0E00D7734D /* RunningRecordView.swift */; };
@@ -106,7 +107,6 @@
 		82CB5F992B8737A200406FBF /* CourseDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5F982B8737A200406FBF /* CourseDetailView.swift */; };
 		82CB5F9E2B874B5000406FBF /* CourseDrawingMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5F9D2B874B5000406FBF /* CourseDrawingMapView.swift */; };
 		82CB5FA02B874C8300406FBF /* LocationMeMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5F9F2B874C8300406FBF /* LocationMeMapView.swift */; };
-		82CB5FA22B874D6500406FBF /* PathPreviewMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5FA12B874D6500406FBF /* PathPreviewMapView.swift */; };
 		82CB5FA42B87625100406FBF /* MapView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5FA32B87625100406FBF /* MapView+.swift */; };
 		82CB5FAC2B87CD4500406FBF /* CourseRegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5FAB2B87CD4500406FBF /* CourseRegisterView.swift */; };
 		82CB5FAE2B87CE6300406FBF /* NavigationDismissButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CB5FAD2B87CE6300406FBF /* NavigationDismissButton.swift */; };
@@ -215,6 +215,7 @@
 		8280E0A72B6CFE7C00D1FB1A /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
 		828EA4BC2B7CB2BC00785D0F /* GraphicTextCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphicTextCard.swift; sourceTree = "<group>"; };
 		828EA4BE2B7CB63100785D0F /* BorderLineModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BorderLineModifier.swift; sourceTree = "<group>"; };
+		829DFDC42BB3478200CD4C1D /* MapboxMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapboxMapView.swift; sourceTree = "<group>"; };
 		829FF7722B6BAAF800C1ED4E /* View+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Keyboard.swift"; sourceTree = "<group>"; };
 		82AB28B02B6B4DC200D7734D /* MenuItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItems.swift; sourceTree = "<group>"; };
 		82AB28B22B6B4F0E00D7734D /* RunningRecordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningRecordView.swift; sourceTree = "<group>"; };
@@ -231,7 +232,6 @@
 		82CB5F982B8737A200406FBF /* CourseDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailView.swift; sourceTree = "<group>"; };
 		82CB5F9D2B874B5000406FBF /* CourseDrawingMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDrawingMapView.swift; sourceTree = "<group>"; };
 		82CB5F9F2B874C8300406FBF /* LocationMeMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationMeMapView.swift; sourceTree = "<group>"; };
-		82CB5FA12B874D6500406FBF /* PathPreviewMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathPreviewMapView.swift; sourceTree = "<group>"; };
 		82CB5FA32B87625100406FBF /* MapView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MapView+.swift"; sourceTree = "<group>"; };
 		82CB5FAB2B87CD4500406FBF /* CourseRegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseRegisterView.swift; sourceTree = "<group>"; };
 		82CB5FAD2B87CE6300406FBF /* NavigationDismissButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDismissButton.swift; sourceTree = "<group>"; };
@@ -403,7 +403,7 @@
 			isa = PBXGroup;
 			children = (
 				82CB5F9F2B874C8300406FBF /* LocationMeMapView.swift */,
-				82CB5FA12B874D6500406FBF /* PathPreviewMapView.swift */,
+				829DFDC42BB3478200CD4C1D /* MapboxMapView.swift */,
 			);
 			path = MapViews;
 			sourceTree = "<group>";
@@ -893,6 +893,7 @@
 				98F1C2F42B6A2386009382B1 /* PhysicalView.swift in Sources */,
 				823B9AD02B6807BF00C9F772 /* ReportView.swift in Sources */,
 				82ECF0B52B67A101002CFD00 /* LoginView.swift in Sources */,
+				829DFDC52BB3478200CD4C1D /* MapboxMapView.swift in Sources */,
 				82ECF0AD2B67A0A2002CFD00 /* MyProfileViewModel.swift in Sources */,
 				82CB5FA42B87625100406FBF /* MapView+.swift in Sources */,
 				981492CF2B8C5DAA0018BDA8 /* ChatListViewModel.swift in Sources */,
@@ -917,7 +918,6 @@
 				610F882C2B77A44100FB12A1 /* AgeGraphView.swift in Sources */,
 				98F1C2F22B6A2374009382B1 /* ProfileImageView.swift in Sources */,
 				82ECF0B32B67A0F8002CFD00 /* AuthenticationViewModel.swift in Sources */,
-				82CB5FA22B874D6500406FBF /* PathPreviewMapView.swift in Sources */,
 				610F882A2B77727900FB12A1 /* CircleTabView.swift in Sources */,
 				82CB5FB82B87F52C00406FBF /* TimePicker.swift in Sources */,
 				820330D82B70127800CB97F7 /* SettingPopup.swift in Sources */,

--- a/TrackUs/TrackUs/Sources/Report/View/MyRecordDetailView.swift
+++ b/TrackUs/TrackUs/Sources/Report/View/MyRecordDetailView.swift
@@ -34,7 +34,7 @@ struct MyRecordDetailView: View {
         
         ZStack {
             GeometryReader { geometry in
-                PathPreviewMap(coordinates: runningLog.coordinates?.toCLLocationCoordinate2D() ?? [])
+                MapboxMapView(coordinates: runningLog.coordinates?.toCLLocationCoordinate2D() ?? [])
                     .onTapGesture {
                         withAnimation {
                             isOpen = false

--- a/TrackUs/TrackUs/Sources/Running/View/CourseDetailView.swift
+++ b/TrackUs/TrackUs/Sources/Running/View/CourseDetailView.swift
@@ -41,7 +41,7 @@ struct CourseDetailView: View {
     
     var body: some View {
         VStack {
-            PathPreviewMap(
+            MapboxMapView(
                 mapStyle: .numberd,
                 coordinates: courseViewModel.course.coordinates
             )

--- a/TrackUs/TrackUs/Sources/Running/View/CourseRegisterView.swift
+++ b/TrackUs/TrackUs/Sources/Running/View/CourseRegisterView.swift
@@ -59,7 +59,7 @@ extension CourseRegisterView {
     var body: some View {
         VStack {
             ScrollView {
-                PathPreviewMap(
+                MapboxMapView(
                     mapStyle: .numberd,
                     isUserInteractionEnabled: false,
                     coordinates: courseViewModel.course.coordinates

--- a/TrackUs/TrackUs/Sources/Running/View/RunningResultView.swift
+++ b/TrackUs/TrackUs/Sources/Running/View/RunningResultView.swift
@@ -13,9 +13,11 @@ struct RunningResultView: View {
     @ObservedObject var trackingViewModel: TrackingViewModel
     @ObservedObject private var settingViewModel = SettingPopupViewModel()
     private let exerciseManager: ExerciseManager!
+    private let mapView: MapboxMapView
     
     @State private var showingPopup = false
     @State private var showingAlert = false
+    @State private var number = 0
     
     init(trackingViewModel: TrackingViewModel, settingViewModel: SettingPopupViewModel = SettingPopupViewModel(), showingPopup: Bool = false, showingAlert: Bool = false) {
         
@@ -29,6 +31,10 @@ struct RunningResultView: View {
             target: trackingViewModel.goalDistance,
             elapsedTime: trackingViewModel.elapsedTime
         )
+        
+        self.mapView = MapboxMapView(
+            coordinates: trackingViewModel.coordinates,
+            trackingViewModel: trackingViewModel)
     }
 }
 
@@ -36,13 +42,11 @@ extension RunningResultView {
     
     var body: some View {
         VStack {
-            PathPreviewMap(
-                coordinates: trackingViewModel.coordinates
-            )
+            mapView
             
             VStack {
                 VStack(spacing: 20) {
-                    
+                    Text("\(number)")
                     RoundedRectangle(cornerRadius: 27)
                         .fill(.indicator)
                         .frame(
@@ -159,6 +163,7 @@ extension RunningResultView {
             SaveDataPopup(showingPopup: $showingPopup, title: $trackingViewModel.title) {
                     self.hideKeyboard()
                     self.showingPopup = false
+                
                     trackingViewModel.addRecord { result in
                         switch result {
                         case .success(let _):


### PR DESCRIPTION
## PR유형을 선택 해주세요 🤔

- [ ] 화면구현
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 디자인 변경
- [ ] 빌드 설정
- [ ] 문서 작업
- [ ] 리펙토링

## PR 체크리스트 ✅
> 다음의 요구 사항을 체크했는지 확인해주세요!!

- [x] 컨벤션에 맞게 커밋 메세지를 작성했습니다.
- [x] 시뮬레이터 혹은 기기에서 빌드가 되는것을 확인했습니다.

## 연관된 이슈 🚨
- #6 
- #5 

## 작업 내용(필요시 스크린샷 첨부)
<img src = "https://github.com/Team-TrackUs/Trackus_iOS/assets/101062450/a110ba6b-9827-4282-88aa-273fdc5bbce0" width = "50%"/> 
<br/>

러닝결과 스크린샷에 경로가 나타나지 않는현상 수정했습니다. 추가적으로 화면이 한번더 넘어가는 현상도 자동으로(?) 수정이 되었네요

```swift
 private func setBoundsOnCenter() {
        DispatchQueue.main.async {
            let referenceCamera = CameraOptions(zoom: 5, bearing: 45)
            
            let camera = try? self.mapView.mapboxMap.camera(
                for: self.coordinates,
                camera: referenceCamera,
                coordinatesPadding: UIEdgeInsets(top: 40, left: 40, bottom: 40, right: 40),
                maxZoom: nil,
                offset: CGPoint(x: 0, y: 40)
            )
            
            self.mapView.camera.ease (
                to: camera!,
                duration: 0) { _ in
                    self.takeSnapshotAndProceed()
                }
        }
    }
    
    private func takeSnapshotAndProceed() {
        if let viewModel = trackingViewModel, let image = UIImage.imageFromView(view: self.mapView) {
            self.trackingViewModel?.snapshot = image
        }
    }
```

러닝결과에 나타나는 맵뷰에서 경로를 그려주고 카메라 포지션이 맞춰지면 캡처를 해주는 방식인데. 뷰컨에서 캡처를 수행하고 SwiftUI 뷰에 데이터를 넘겨주는 좋은 방식이 생각나지 않아서 우선 뷰모델에 저장하도록 처리를 했습니다.

## 리뷰어 전달사항
